### PR TITLE
Simplify skill usage documentation

### DIFF
--- a/skills/arxiv-search/SKILL.md
+++ b/skills/arxiv-search/SKILL.md
@@ -30,20 +30,19 @@ Search the complete arXiv database of preprints across physics, mathematics, com
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-ARXIV_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/arxiv-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/arxiv-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$ARXIV_SCRIPT "quantum entanglement" 15
+~/.claude/skills/arxiv-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/biomedical-search/SKILL.md
+++ b/skills/biomedical-search/SKILL.md
@@ -30,20 +30,19 @@ Search across all major biomedical databases (PubMed, bioRxiv, medRxiv, Clinical
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-BIOMEDICAL_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/biomedical-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/biomedical-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$BIOMEDICAL_SCRIPT "CAR-T cell therapy" 20
+~/.claude/skills/biomedical-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/biorxiv-search/SKILL.md
+++ b/skills/biorxiv-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete bioRxiv database of biological sciences preprints using natu
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-BIORXIV_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/biorxiv-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/biorxiv-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$BIORXIV_SCRIPT "CRISPR gene editing" 15
+~/.claude/skills/biorxiv-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/chembl-search/SKILL.md
+++ b/skills/chembl-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete ChEMBL database of bioactive molecules, drug targets, and bi
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-CHEMBL_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/chembl-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/chembl-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$CHEMBL_SCRIPT "kinase inhibitors" 15
+~/.claude/skills/chembl-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/clinical-trials-search/SKILL.md
+++ b/skills/clinical-trials-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete ClinicalTrials.gov database of clinical studies using natura
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-CLINICAL_TRIALS_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/clinical-trials-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/clinical-trials-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$CLINICAL_TRIALS_SCRIPT "CAR-T cell therapy trials" 15
+~/.claude/skills/clinical-trials-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/drug-discovery-search/SKILL.md
+++ b/skills/drug-discovery-search/SKILL.md
@@ -30,20 +30,19 @@ Search across all major drug discovery databases (ChEMBL, DrugBank, FDA drug lab
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-DRUG_DISCOVERY_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/drug-discovery-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/drug-discovery-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$DRUG_DISCOVERY_SCRIPT "JAK2 inhibitors" 20
+~/.claude/skills/drug-discovery-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/drug-labels-search/SKILL.md
+++ b/skills/drug-labels-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete FDA drug labels database including prescribing information, 
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-DRUG_LABELS_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/drug-labels-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/drug-labels-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$DRUG_LABELS_SCRIPT "ibuprofen warnings" 15
+~/.claude/skills/drug-labels-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/drugbank-search/SKILL.md
+++ b/skills/drugbank-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete DrugBank database of drug information including mechanisms o
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-DRUGBANK_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/drugbank-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/drugbank-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$DRUGBANK_SCRIPT "ACE inhibitors" 15
+~/.claude/skills/drugbank-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/literature-search/SKILL.md
+++ b/skills/literature-search/SKILL.md
@@ -30,20 +30,19 @@ Search across all major scientific literature databases (PubMed, arXiv, bioRxiv,
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-LITERATURE_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/literature-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/literature-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$LITERATURE_SCRIPT "CRISPR gene editing advances" 15
+~/.claude/skills/literature-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/medrxiv-search/SKILL.md
+++ b/skills/medrxiv-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete medRxiv database of medical and health sciences preprints us
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-MEDRXIV_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/medrxiv-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/medrxiv-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$MEDRXIV_SCRIPT "COVID-19 vaccine efficacy" 15
+~/.claude/skills/medrxiv-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/open-targets-search/SKILL.md
+++ b/skills/open-targets-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete Open Targets database of drug-disease associations and targe
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-OPEN_TARGETS_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/open-targets-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/open-targets-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$OPEN_TARGETS_SCRIPT "JAK2 inhibitors" 15
+~/.claude/skills/open-targets-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/patents-search/SKILL.md
+++ b/skills/patents-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete global patent database using natural language queries powere
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-PATENTS_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/patents-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/patents-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$PATENTS_SCRIPT "CRISPR gene editing methods" 15
+~/.claude/skills/patents-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 

--- a/skills/pubmed-search/SKILL.md
+++ b/skills/pubmed-search/SKILL.md
@@ -29,20 +29,19 @@ Search the complete PubMed database of biomedical literature using natural langu
 1. Node.js 18+ (uses built-in fetch)
 2. Valyu API key from https://platform.valyu.ai ($10 free credits)
 
-## CRITICAL: Script Path Resolution
+## Usage
 
-The `scripts/search` commands in this documentation are relative to this skill's installation directory.
-
-Before running any command, locate the script using:
+Run searches using the installed skill path:
 
 ```bash
-PUBMED_SCRIPT=$(find ~/.claude/plugins/cache -name "search" -path "*/pubmed-search/*/scripts/*" -type f 2>/dev/null | head -1)
+~/.claude/skills/pubmed-search/scripts/search "your search query" 20
 ```
 
-Then use the full path for all commands:
+Example:
 ```bash
-$PUBMED_SCRIPT "CRISPR gene editing" 15
+~/.claude/skills/pubmed-search/scripts/search "kinase inhibitors" 15
 ```
+
 
 ## API Key Setup Flow
 


### PR DESCRIPTION
## Summary

- Replaces the complex "CRITICAL: Script Path Resolution" section in all SKILL.md files with a simple, straightforward usage section
- Updates all 13 skill documentation files to use the standard `~/.claude/skills/SKILLNAME/scripts/search` path
- Removes the need for users to run `find` commands to locate scripts before use
- Makes the documentation more user-friendly and consistent across all skills

## Changes

Updated SKILL.md files for:
- chembl-search
- pubmed-search
- arxiv-search
- biorxiv-search
- medrxiv-search
- drugbank-search
- clinical-trials-search
- drug-labels-search
- open-targets-search
- patents-search
- literature-search
- biomedical-search
- drug-discovery-search

## Test plan

- [ ] Verify the new usage instructions work correctly
- [ ] Test at least one skill to confirm the path `~/.claude/skills/SKILLNAME/scripts/search` is correct
- [ ] Confirm the documentation reads clearly and is easy to follow

Generated with [Claude Code](https://claude.com/claude-code)